### PR TITLE
Get the tutorials' children recursively

### DIFF
--- a/lib/publishjob.js
+++ b/lib/publishjob.js
@@ -203,16 +203,20 @@ PublishJob.prototype.generateTocData = function generateTocData(navTree, options
     return this.generate('toc', { tocData: tocData }, 'scripts/jsdoc-toc.js');
 };
 
+/**
+ * Get Tutorial Children recursively
+ * @param tutorial
+ */
+PublishJob.prototype.getTutorialChildren = function (tutorial) {
+    var children = tutorial.children;
+    tutorial.children.forEach(function (child) {
+        children = children.concat(this.getTutorialChildren(child));
+    }, this);
+    return children;
+};
+
 PublishJob.prototype.generateTutorials = function generateTutorials(tutorials) {
-    var children = [];
-    var self = this;
-
-    while (tutorials.children.length) {
-        children = children.concat(tutorials.children);
-        tutorials = tutorials.children;
-    }
-
-    children.forEach(function(child) {
+    this.getTutorialChildren(tutorials).forEach(function(child) {
         var title = removeLeadingNamespace(child.title);
         var tutorialData = {
             pageCategory: CATEGORIES.TUTORIALS,
@@ -221,11 +225,9 @@ PublishJob.prototype.generateTutorials = function generateTutorials(tutorials) {
             content: child.parse(),
             children: child.children
         };
-        var url = helper.tutorialToUrl(child.title);
-
-        self.generate('tutorial', tutorialData, url);
-    });
-
+        var url = helper.tutorialToUrl(child.name);
+        this.generate('tutorial', tutorialData, url);
+    }, this);
     return this;
 };
 


### PR DESCRIPTION
I got this error when trying to generate the documentation:

```
jsdoc-baseline/lib/publishjob.js:211
    while (tutorials.children.length) {
                             ^
TypeError: Cannot read property 'length' of undefined
```

It was due to the fact that inside the loop, the variable tutorials, originally an object with a children property, is reassigned to tutorials.children which is an array. I replaced the while loop by a recursive function.

I also fixed an error triggered by helper.tutorialToUrl by passing along the name instead of the title.

Let me know what you think about the internal declaration of the recursive function. Would you prefer to have it defined outside the generateTutorials method?
