### PR TITLE
Add a translation for externals

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -51,6 +51,7 @@
     "events": "Event |||| Events",
     "examples": "Example |||| Examples",
     "exports": "Exports",
+    "externals": "External |||| Externals",
     "fires": "Fires",
     "functions": "Method |||| Methods",
     "globals": "Global |||| Globals",


### PR DESCRIPTION
When attempting to generate the documentation, I got the following warning:

```
Unable to find a localized string for the key headings.externals
```

I added a translation to eng.json to fix my issue.
