### PR TITLE
Add missed regexp escaping and allow HTML escapes in field names.

### DIFF
--- a/lib/helpers/expression/index.js
+++ b/lib/helpers/expression/index.js
@@ -1006,7 +1006,7 @@ module.exports = function(template) {
                     }
 
                     if (parentItem && parentItem.name && item.name) {
-                        itemRegExp = new RegExp('^(?:' + parentItem.name + '(?:\\[\\])*)\\.(.+)$');
+                        itemRegExp = new RegExp('^(?:' + escape(parentItem.name) + '(?:\\[\\])*)\\.(.+)$');
 
                         if (itemRegExp.test(item.name)) {
                             // clone the item (and manually clone a non-enumerable property that we

--- a/views/partials/details-table-row.hbs
+++ b/views/partials/details-table-row.hbs
@@ -1,7 +1,7 @@
 <tr>
     {{#block 'details-table-name'}}
         <td {{~cssClass 'details-table-name'}}>
-            <p>{{#if name}}{{name}}{{else}}{{translate 'tables.notApplicable'}}{{/if}}</p>
+            <p>{{#if name}}{{{name}}}{{else}}{{translate 'tables.notApplicable'}}{{/if}}</p>
         </td>
     {{/block}}
     {{#block 'details-table-types'}}


### PR DESCRIPTION
Normally JSDoc allows HTML escape codes in field names, so it should be allowed here (by using
triple curly brackets in the handlebars template).