### PR TITLE
fix: intl-messageformat@3.x exports invalid JavaScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2920,17 +2920,17 @@
       "dev": true
     },
     "intl-messageformat": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-3.0.0.tgz",
-      "integrity": "sha512-7Vfr+ub/SNdLY+VxHBLN5WDs/jcdWSBbXdKXxaLG8m7V98C8mXmLeCyqzaRBn2bC7ZxNmXvdSCjXWVzUULFXyg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
+      "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
       "requires": {
-        "intl-messageformat-parser": "1.6.0"
+        "intl-messageformat-parser": "1.4.0"
       }
     },
     "intl-messageformat-parser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.6.0.tgz",
-      "integrity": "sha512-qwTdo6gcrM3vwxBLYCOkI3SZLGxc3UBVdlqSH0AsPwgTS3VyysQzWWSGSLA1m1o9UkoKVZZURcNtbdgXge6Tqg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
+      "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU="
     },
     "intl-pluralrules": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "escape-string-regexp": "^2.0.0",
     "handlebars": "^4.1.2",
     "handlebars-layouts": "^3.1.4",
-    "intl-messageformat": "^3.0.0",
+    "intl-messageformat": "^2.2.0",
     "intl-pluralrules": "^1.0.1",
     "js-beautify": "^1.9.1",
     "js-yaml": "^3.13.1",


### PR DESCRIPTION
When running the latest version of `jsdoc-baseline`, builds fail due to `intl-messageformat` including invalid JavaScript:

```
/usr/local/google/home/bencoe/google/nodejs-automl/node_modules/jsdoc-baseline/node_modules/intl-messageformat/lib/index.js:1
(function (exports, require, module, __filename, __dirname) { module.paths = ["/usr/local/google/home/bencoe/google/nodejs-automl/node_modules/jsdoc/lib"].concat(module.paths).concat(["/usr/local/google/home/bencoe/google/nodejs-automl/node_modules/jsdoc/node_modules"]); import IntlMessageFormat from './core';
                                                                                                                                                                                                                                                                                       ^^^^^^^^^^^^^^^^^
```
 
``
import IntlMessageFormat from './core
```

will not work without transpilation or `--experimental-modules` turned on in Node.js; downgrading the dependency fixes the issue.